### PR TITLE
Disable fp16 for multi-gpu training support

### DIFF
--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -742,7 +742,7 @@ class BertModel(BertPreTrainedModel):
         # positions we want to attend and -10000.0 for masked positions.
         # Since we are adding it to the raw scores before the softmax, this is
         # effectively the same as removing these entirely.
-        extended_attention_mask = extended_attention_mask.to(dtype=next(self.parameters()).dtype)  # fp16 compatibility
+        #extended_attention_mask = extended_attention_mask.to(dtype=next(self.parameters()).dtype)  # fp16 compatibility
         extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
 
         # If a 2D ou 3D attention mask is provided for the cross-attention
@@ -764,9 +764,9 @@ class BertModel(BertPreTrainedModel):
                     )
                 )
 
-            encoder_extended_attention_mask = encoder_extended_attention_mask.to(
-                dtype=next(self.parameters()).dtype
-            )  # fp16 compatibility
+        #    encoder_extended_attention_mask = encoder_extended_attention_mask.to(
+        #        dtype=next(self.parameters()).dtype
+        #    )  # fp16 compatibility
             encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * -10000.0
         else:
             encoder_extended_attention_mask = None
@@ -784,9 +784,9 @@ class BertModel(BertPreTrainedModel):
                 head_mask = (
                     head_mask.unsqueeze(1).unsqueeze(-1).unsqueeze(-1)
                 )  # We can specify head_mask for each layer
-            head_mask = head_mask.to(
-                dtype=next(self.parameters()).dtype
-            )  # switch to fload if need + fp16 compatibility
+        #    head_mask = head_mask.to(
+        #        dtype=next(self.parameters()).dtype
+        #    )  # switch to fload if need + fp16 compatibility
         else:
             head_mask = [None] * self.config.num_hidden_layers
 


### PR DESCRIPTION
Found the fp16 option in modeling_bert.py would cause the multi-gpu training error, so disabled as a temporary fix since low precision training is not our focus for now. After the fix, the training with 4 GPUs took less than 20 mins in total. 

```
12/28/2020 10:55:47 - INFO - __main__ -   ***** Eval results  *****
12/28/2020 10:55:47 - INFO - __main__ -     acc = 0.8670383510728163
12/28/2020 10:55:47 - INFO - __main__ -     auc = 0.9438935050578645
12/28/2020 10:55:47 - INFO - __main__ -     aupr = 0.9405987763741833
12/28/2020 10:55:47 - INFO - __main__ -     f1 = 0.8679308608826984
12/28/2020 10:55:47 - INFO - __main__ -     mcc = 0.7348886781245071
12/28/2020 10:55:47 - INFO - __main__ -     precision = 0.8495400788436268
12/28/2020 10:55:47 - INFO - __main__ -     recall = 0.8871355060034305
```
